### PR TITLE
feat: broker graph auto-update - parametric from/to endpoint

### DIFF
--- a/src/main/java/com/rondinella/moneymanageapi/brokertransactions/BrokerTransactionsController.java
+++ b/src/main/java/com/rondinella/moneymanageapi/brokertransactions/BrokerTransactionsController.java
@@ -24,9 +24,11 @@ public class BrokerTransactionsController {
   }
 
   @GetMapping("/worth/graph")
-  public GraphPointsDto worthGraph() {
-    Timestamp f = Utils.stringToTimestamp("2021-01-01");
-    Timestamp t = Utils.todayAsTimestamp();
+  public GraphPointsDto worthGraph(
+      @RequestParam(required = false) Timestamp from,
+      @RequestParam(required = false) Timestamp to) {
+    Timestamp f = from != null ? from : Utils.stringToTimestamp("2021-01-01");
+    Timestamp t = to != null ? to : Utils.todayAsTimestamp();
     return brokerTransactionService.worthGraph(f, t);
   }
 


### PR DESCRIPTION
## Summary
- Endpoint `GET /api/brokers/transactions/worth/graph` ora accetta parametri opzionali `from` e `to`
- Se non specificati, usa i default: `2021-01-01` → oggi (comportamento invariato)

## Test plan
- [ ] Chiamare `/worth/graph` senza parametri → risposta identica a prima
- [ ] Chiamare `/worth/graph?from=2023-01-01&to=2024-01-01` → filtra il range

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)