### PR TITLE
feat: separate DailyBalance table [superseded by #15]

### DIFF
--- a/src/main/java/com/rondinella/moneymanageapi/banktransactions/BankTransactionService.java
+++ b/src/main/java/com/rondinella/moneymanageapi/banktransactions/BankTransactionService.java
@@ -11,6 +11,7 @@ import java.io.StringReader;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.*;
+import java.util.LinkedHashMap;
 
 @Service
 public class BankTransactionService {
@@ -22,10 +23,13 @@ public class BankTransactionService {
 
   final
   BankTransactionRepository bankTransactionRepository;
+  final
+  DailyBalanceRepository dailyBalanceRepository;
   BankTransactionMapper bankTransactionMapper = BankTransactionMapper.INSTANCE;
 
-  public BankTransactionService(BankTransactionRepository bankTransactionRepository) {
+  public BankTransactionService(BankTransactionRepository bankTransactionRepository, DailyBalanceRepository dailyBalanceRepository) {
     this.bankTransactionRepository = bankTransactionRepository;
+    this.dailyBalanceRepository = dailyBalanceRepository;
   }
 
   public List<BankTransactionDto> findAllTransactions() {
@@ -54,6 +58,17 @@ public class BankTransactionService {
 
     bankTransactionRepository.saveAllAndFlush(bankTransactions);
 
+    // Populate daily balance snapshot table
+    List<BankTransaction> ordered = bankTransactionRepository.findTransactionByAccountOrderByDatetime(account);
+    Map<java.time.LocalDate, BigDecimal> dailyMap = new java.util.LinkedHashMap<>();
+    for (BankTransaction tx : ordered) {
+      java.time.LocalDate day = tx.getDatetime().toLocalDateTime().toLocalDate();
+      dailyMap.put(day, tx.getCumulativeAmount());
+    }
+    List<DailyBalance> snapshots = new ArrayList<>();
+    dailyMap.forEach((date, balance) -> snapshots.add(new DailyBalance(account, date, balance)));
+    dailyBalanceRepository.saveAllAndFlush(snapshots);
+
     return true;
   }
 
@@ -74,6 +89,10 @@ public class BankTransactionService {
     return sum;
   }
 
+
+  public List<DailyBalance> getDailyBalance(String account) {
+    return dailyBalanceRepository.findByAccountOrderByDate(account);
+  }
 
   public List<BankTransactionDto> historyBetweenDates(Timestamp startTimestamp, Timestamp endTimestamp, String account) {
     List<BankTransaction> bankTransactions = bankTransactionRepository.findByDatetimeBetweenAndAccount(startTimestamp, endTimestamp, account);
@@ -97,15 +116,25 @@ public class BankTransactionService {
 
   public GraphPointsDto historyBetweenDates(Timestamp startTimestamp, Timestamp endTimestamp) {
     GraphPointsDto result = new GraphPointsDto();
-    LinkedHashSet<String> daysList = Utils.getAllDaysBetweenTimestamps(startTimestamp, endTimestamp);
     List<String> accounts = bankTransactionRepository.findDistinctAccounts();
 
+    java.time.LocalDate from = startTimestamp.toLocalDateTime().toLocalDate();
+    java.time.LocalDate to = endTimestamp.toLocalDateTime().toLocalDate();
+
     for (String account : accounts) {
-      Map<String, BigDecimal> points = new HashMap<>();
-      List<BankTransaction> bankTransactions = bankTransactionRepository.findByDatetimeBetweenAndAccountOrderByDatetime(startTimestamp, endTimestamp, account);
-      for (BankTransaction bankTransaction : bankTransactions) {
-        String simpleDate = Utils.convertTimestampToString(bankTransaction.getDatetime());
-        points.put(simpleDate, bankTransaction.getCumulativeAmount());
+      List<DailyBalance> snapshots = dailyBalanceRepository.findByAccountAndDateBetweenOrderByDate(account, from, to);
+      Map<String, BigDecimal> points = new LinkedHashMap<>();
+      if (!snapshots.isEmpty()) {
+        for (DailyBalance snapshot : snapshots) {
+          points.put(snapshot.getDate().toString(), snapshot.getBalance());
+        }
+      } else {
+        // Fallback: compute from raw transactions
+        List<BankTransaction> bankTransactions = bankTransactionRepository.findByDatetimeBetweenAndAccountOrderByDatetime(startTimestamp, endTimestamp, account);
+        for (BankTransaction bankTransaction : bankTransactions) {
+          String simpleDate = Utils.convertTimestampToString(bankTransaction.getDatetime());
+          points.put(simpleDate, bankTransaction.getCumulativeAmount());
+        }
       }
       result.addPoints(account, points);
     }

--- a/src/main/java/com/rondinella/moneymanageapi/banktransactions/BankTransactionsController.java
+++ b/src/main/java/com/rondinella/moneymanageapi/banktransactions/BankTransactionsController.java
@@ -70,4 +70,9 @@ public class BankTransactionsController {
   public ResponseEntity<?> uploadTransactions(@RequestBody String csvData, @PathVariable BankName bankName) {
     return ResponseEntity.status(HttpStatus.CREATED).body(bankTransactionService.addTransactionsFromCsv(csvData, bankName));
   }
+
+  @GetMapping("/daily-balance/{accountName}")
+  public ResponseEntity<?> getDailyBalance(@PathVariable String accountName) {
+    return ResponseEntity.ok(bankTransactionService.getDailyBalance(accountName));
+  }
 }

--- a/src/main/java/com/rondinella/moneymanageapi/banktransactions/DailyBalance.java
+++ b/src/main/java/com/rondinella/moneymanageapi/banktransactions/DailyBalance.java
@@ -1,0 +1,26 @@
+package com.rondinella.moneymanageapi.banktransactions;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@IdClass(DailyBalanceId.class)
+public class DailyBalance {
+  @Id
+  String account;
+  @Id
+  LocalDate date;
+  BigDecimal balance;
+}

--- a/src/main/java/com/rondinella/moneymanageapi/banktransactions/DailyBalanceId.java
+++ b/src/main/java/com/rondinella/moneymanageapi/banktransactions/DailyBalanceId.java
@@ -1,0 +1,18 @@
+package com.rondinella.moneymanageapi.banktransactions;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DailyBalanceId implements Serializable {
+  String account;
+  LocalDate date;
+}

--- a/src/main/java/com/rondinella/moneymanageapi/banktransactions/DailyBalanceRepository.java
+++ b/src/main/java/com/rondinella/moneymanageapi/banktransactions/DailyBalanceRepository.java
@@ -1,0 +1,14 @@
+package com.rondinella.moneymanageapi.banktransactions;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Hidden
+public interface DailyBalanceRepository extends JpaRepository<DailyBalance, DailyBalanceId> {
+  List<DailyBalance> findByAccountAndDateBetweenOrderByDate(String account, LocalDate from, LocalDate to);
+
+  List<DailyBalance> findByAccountOrderByDate(String account);
+}


### PR DESCRIPTION
## Summary
- Nuova entity `DailyBalance` con chiave composita (account, date) e campo `balance`
- `computeCumulativeAmount()` ora popola anche la tabella `DailyBalance` dopo il calcolo
- `historyBetweenDates()` legge da `DailyBalance` (più efficiente), con fallback su raw transactions se i snapshot non esistono ancora
- Nuovo endpoint `GET /api/banks/transactions/daily-balance/{account}` per query diretta

## Test plan
- [ ] Chiamare `computeCumulativeAmount` per un account → verificare che la tabella `DailyBalance` si popoli
- [ ] Chiamare `GET /api/banks/transactions/graph/{from}/{to}` → dati corretti e più veloci
- [ ] Chiamare `GET /api/banks/transactions/daily-balance/{account}` → lista snapshot

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)