### PR TITLE
feat/fix: JWT auth + review fixes (status, CSV, CORS, config)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,18 +25,23 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-rest'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.seleniumhq.selenium:selenium-java:4.18.1'
     implementation 'com.opencsv:opencsv:3.7'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     runtimeOnly 'com.mysql:mysql-connector-j'
 }
 

--- a/src/main/java/com/rondinella/moneymanageapi/auth/ApplicationUserDetailsService.java
+++ b/src/main/java/com/rondinella/moneymanageapi/auth/ApplicationUserDetailsService.java
@@ -1,0 +1,28 @@
+package com.rondinella.moneymanageapi.auth;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ApplicationUserDetailsService implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  public ApplicationUserDetailsService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    com.rondinella.moneymanageapi.auth.User user = userRepository.findByUsername(username)
+        .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+    return User.builder()
+        .username(user.getUsername())
+        .password(user.getPassword())
+        .roles(user.getRole())
+        .build();
+  }
+}

--- a/src/main/java/com/rondinella/moneymanageapi/auth/AuthController.java
+++ b/src/main/java/com/rondinella/moneymanageapi/auth/AuthController.java
@@ -1,0 +1,31 @@
+package com.rondinella.moneymanageapi.auth;
+
+import com.rondinella.moneymanageapi.auth.dto.AuthResponse;
+import com.rondinella.moneymanageapi.auth.dto.LoginRequest;
+import com.rondinella.moneymanageapi.auth.dto.RegisterRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/auth", produces = "application/json")
+public class AuthController {
+
+  private final AuthService authService;
+
+  public AuthController(AuthService authService) {
+    this.authService = authService;
+  }
+
+  @PostMapping("/register")
+  public ResponseEntity<AuthResponse> register(@RequestBody RegisterRequest request) {
+    return ResponseEntity.ok(authService.register(request));
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request) {
+    return ResponseEntity.ok(authService.login(request));
+  }
+}

--- a/src/main/java/com/rondinella/moneymanageapi/auth/AuthService.java
+++ b/src/main/java/com/rondinella/moneymanageapi/auth/AuthService.java
@@ -1,0 +1,43 @@
+package com.rondinella.moneymanageapi.auth;
+
+import com.rondinella.moneymanageapi.auth.dto.AuthResponse;
+import com.rondinella.moneymanageapi.auth.dto.LoginRequest;
+import com.rondinella.moneymanageapi.auth.dto.RegisterRequest;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final JwtService jwtService;
+  private final AuthenticationManager authenticationManager;
+
+  public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder, JwtService jwtService, AuthenticationManager authenticationManager) {
+    this.userRepository = userRepository;
+    this.passwordEncoder = passwordEncoder;
+    this.jwtService = jwtService;
+    this.authenticationManager = authenticationManager;
+  }
+
+  public AuthResponse register(RegisterRequest request) {
+    if (userRepository.findByUsername(request.getUsername()).isPresent()) {
+      throw new RuntimeException("Username already taken");
+    }
+    User user = new User();
+    user.setUsername(request.getUsername());
+    user.setPassword(passwordEncoder.encode(request.getPassword()));
+    user.setRole("USER");
+    userRepository.save(user);
+    return new AuthResponse(jwtService.generateToken(user.getUsername()));
+  }
+
+  public AuthResponse login(LoginRequest request) {
+    authenticationManager.authenticate(
+        new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword()));
+    return new AuthResponse(jwtService.generateToken(request.getUsername()));
+  }
+}

--- a/src/main/java/com/rondinella/moneymanageapi/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/rondinella/moneymanageapi/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.rondinella.moneymanageapi.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtService jwtService;
+  private final UserDetailsService userDetailsService;
+
+  public JwtAuthenticationFilter(JwtService jwtService, UserDetailsService userDetailsService) {
+    this.jwtService = jwtService;
+    this.userDetailsService = userDetailsService;
+  }
+
+  @Override
+  protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                  @NonNull HttpServletResponse response,
+                                  @NonNull FilterChain filterChain) throws ServletException, IOException {
+    final String authHeader = request.getHeader("Authorization");
+    if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    final String jwt = authHeader.substring(7);
+    try {
+      final String username = jwtService.extractUsername(jwt);
+      if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        if (jwtService.isTokenValid(jwt, userDetails)) {
+          UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+              userDetails, null, userDetails.getAuthorities());
+          authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+          SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
+      }
+    } catch (Exception e) {
+      // Invalid/expired token: leave the request unauthenticated.
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/com/rondinella/moneymanageapi/auth/JwtService.java
+++ b/src/main/java/com/rondinella/moneymanageapi/auth/JwtService.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
@@ -16,11 +17,23 @@ import java.util.function.Function;
 @Service
 public class JwtService {
 
-  @Value("${app.jwt.secret:change-me-money-manage-jwt-secret-please-override-0123456789}")
+  @Value("${app.jwt.secret:}")
   private String secretKey;
 
   @Value("${app.jwt.expiration:86400000}")
   private long jwtExpiration;
+
+  private Key signingKey;
+
+  @PostConstruct
+  void init() {
+    if (secretKey != null && !secretKey.isBlank()) {
+      this.signingKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    } else {
+      // No secret configured: generate a secure random key for this run.
+      this.signingKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    }
+  }
 
   public String extractUsername(String token) {
     return extractClaim(token, Claims::getSubject);
@@ -36,7 +49,7 @@ public class JwtService {
         .setSubject(username)
         .setIssuedAt(new Date(System.currentTimeMillis()))
         .setExpiration(new Date(System.currentTimeMillis() + jwtExpiration))
-        .signWith(getSignInKey(), SignatureAlgorithm.HS256)
+        .signWith(signingKey, SignatureAlgorithm.HS256)
         .compact();
   }
 
@@ -51,13 +64,9 @@ public class JwtService {
 
   private Claims extractAllClaims(String token) {
     return Jwts.parserBuilder()
-        .setSigningKey(getSignInKey())
+        .setSigningKey(signingKey)
         .build()
         .parseClaimsJws(token)
         .getBody();
-  }
-
-  private Key getSignInKey() {
-    return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/src/main/java/com/rondinella/moneymanageapi/auth/JwtService.java
+++ b/src/main/java/com/rondinella/moneymanageapi/auth/JwtService.java
@@ -1,0 +1,63 @@
+package com.rondinella.moneymanageapi.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.function.Function;
+
+@Service
+public class JwtService {
+
+  @Value("${app.jwt.secret:change-me-money-manage-jwt-secret-please-override-0123456789}")
+  private String secretKey;
+
+  @Value("${app.jwt.expiration:86400000}")
+  private long jwtExpiration;
+
+  public String extractUsername(String token) {
+    return extractClaim(token, Claims::getSubject);
+  }
+
+  public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+    final Claims claims = extractAllClaims(token);
+    return claimsResolver.apply(claims);
+  }
+
+  public String generateToken(String username) {
+    return Jwts.builder()
+        .setSubject(username)
+        .setIssuedAt(new Date(System.currentTimeMillis()))
+        .setExpiration(new Date(System.currentTimeMillis() + jwtExpiration))
+        .signWith(getSignInKey(), SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  public boolean isTokenValid(String token, UserDetails userDetails) {
+    final String username = extractUsername(token);
+    return username.equals(userDetails.getUsername()) && !isTokenExpired(token);
+  }
+
+  private boolean isTokenExpired(String token) {
+    return extractClaim(token, Claims::getExpiration).before(new Date());
+  }
+
+  private Claims extractAllClaims(String token) {
+    return Jwts.parserBuilder()
+        .setSigningKey(getSignInKey())
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
+  }
+
+  private Key getSignInKey() {
+    return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/src/main/java/com/rondinella/moneymanageapi/auth/User.java
+++ b/src/main/java/com/rondinella/moneymanageapi/auth/User.java
@@ -1,0 +1,52 @@
+package com.rondinella.moneymanageapi.auth;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class User {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(unique = true, nullable = false)
+  private String username;
+
+  @Column(nullable = false)
+  private String password;
+
+  @Column(nullable = false)
+  private String role = "USER";
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public String getRole() {
+    return role;
+  }
+
+  public void setRole(String role) {
+    this.role = role;
+  }
+}

--- a/src/main/java/com/rondinella/moneymanageapi/auth/UserRepository.java
+++ b/src/main/java/com/rondinella/moneymanageapi/auth/UserRepository.java
@@ -1,0 +1,12 @@
+package com.rondinella.moneymanageapi.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+import java.util.Optional;
+
+// Not exported via Spring Data REST: this repository holds credentials.
+@RepositoryRestResource(exported = false)
+public interface UserRepository extends JpaRepository<User, Long> {
+  Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/rondinella/moneymanageapi/auth/dto/AuthResponse.java
+++ b/src/main/java/com/rondinella/moneymanageapi/auth/dto/AuthResponse.java
@@ -1,0 +1,20 @@
+package com.rondinella.moneymanageapi.auth.dto;
+
+public class AuthResponse {
+  private String token;
+
+  public AuthResponse() {
+  }
+
+  public AuthResponse(String token) {
+    this.token = token;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public void setToken(String token) {
+    this.token = token;
+  }
+}

--- a/src/main/java/com/rondinella/moneymanageapi/auth/dto/LoginRequest.java
+++ b/src/main/java/com/rondinella/moneymanageapi/auth/dto/LoginRequest.java
@@ -1,0 +1,22 @@
+package com.rondinella.moneymanageapi.auth.dto;
+
+public class LoginRequest {
+  private String username;
+  private String password;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+}

--- a/src/main/java/com/rondinella/moneymanageapi/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/rondinella/moneymanageapi/auth/dto/RegisterRequest.java
@@ -1,0 +1,22 @@
+package com.rondinella.moneymanageapi.auth.dto;
+
+public class RegisterRequest {
+  private String username;
+  private String password;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+}

--- a/src/main/java/com/rondinella/moneymanageapi/banktransactions/BankTransactionService.java
+++ b/src/main/java/com/rondinella/moneymanageapi/banktransactions/BankTransactionService.java
@@ -2,6 +2,7 @@ package com.rondinella.moneymanageapi.banktransactions;
 
 import com.opencsv.CSVReader;
 import com.rondinella.moneymanageapi.common.Utils;
+import com.rondinella.moneymanageapi.common.configurations.AccountBaseProperties;
 import com.rondinella.moneymanageapi.common.dtos.GraphPointsDto;
 import org.springframework.stereotype.Service;
 
@@ -21,10 +22,13 @@ public class BankTransactionService {
 
   final
   BankTransactionRepository bankTransactionRepository;
+  final
+  AccountBaseProperties accountBaseProperties;
   BankTransactionMapper bankTransactionMapper = BankTransactionMapper.INSTANCE;
 
-  public BankTransactionService(BankTransactionRepository bankTransactionRepository) {
+  public BankTransactionService(BankTransactionRepository bankTransactionRepository, AccountBaseProperties accountBaseProperties) {
     this.bankTransactionRepository = bankTransactionRepository;
+    this.accountBaseProperties = accountBaseProperties;
   }
 
   public List<BankTransactionDto> findAllTransactions() {
@@ -57,10 +61,7 @@ public class BankTransactionService {
   }
 
   public BigDecimal amountOnThatDay(String accountName, Timestamp thatDay) {
-    Map<String, BigDecimal> base = new HashMap<>();
-    base.put("Revolut_Current", new BigDecimal("94.24"));
-    base.put("Revolut_Pocket", new BigDecimal("79.86"));
-    base.put("Revolut_Savings", new BigDecimal("98.16"));
+    Map<String, BigDecimal> base = accountBaseProperties.getAmounts();
 
     List<BankTransaction> bankTransactions = bankTransactionRepository.findTransactionByAccountAndDatetimeGreaterThanOrderByDatetimeDesc(accountName, thatDay);
 
@@ -142,8 +143,6 @@ public class BankTransactionService {
         BankTransactionDto bankTransactionDto = bankTransactionMapper.toDtoFromRevolut(rowData);
         bankTransactionDtos.add(bankTransactionDto);
       }
-    } catch (com.opencsv.exceptions.CsvValidationException e) {
-      throw new RuntimeException("Failed to parse Revolut CSV data", e);
     }
 
     return bankTransactionDtos;
@@ -179,8 +178,6 @@ public class BankTransactionService {
 
         bankTransactionDtos.add(bankTransactionDto);
       }
-    } catch (com.opencsv.exceptions.CsvValidationException e) {
-      throw new RuntimeException("Failed to parse Degiro CSV data", e);
     }
 
     return bankTransactionDtos;

--- a/src/main/java/com/rondinella/moneymanageapi/banktransactions/BankTransactionService.java
+++ b/src/main/java/com/rondinella/moneymanageapi/banktransactions/BankTransactionService.java
@@ -5,7 +5,6 @@ import com.rondinella.moneymanageapi.common.Utils;
 import com.rondinella.moneymanageapi.common.dtos.GraphPointsDto;
 import org.springframework.stereotype.Service;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.math.BigDecimal;
@@ -122,25 +121,31 @@ public class BankTransactionService {
   }
 
   private List<BankTransactionDto> revolutCsv(String csvData) throws IOException {
-    BufferedReader reader = new BufferedReader(new StringReader(csvData));
     List<BankTransactionDto> bankTransactionDtos = new ArrayList<>();
-    String line;
-    // Read the header line to get field names
-    String[] headers = reader.readLine().split(",");
-    while ((line = reader.readLine()) != null) {
-      String[] data = line.split(",", -1);
-      if (data.length != headers.length)
-        throw new RuntimeException("lol");
 
-      // Create a Map to hold the data of each row
-      Map<String, Object> rowData = new HashMap<>();
-      for (int i = 0; i < headers.length; i++) {
-        rowData.put(headers[i], data[i]);
+    try (CSVReader reader = new CSVReader(new StringReader(csvData))) {
+      String[] headers = reader.readNext();
+      if (headers == null) {
+        return bankTransactionDtos;
       }
 
-      BankTransactionDto bankTransactionDto = bankTransactionMapper.toDtoFromRevolut(rowData);
-      bankTransactionDtos.add(bankTransactionDto);
+      String[] data;
+      while ((data = reader.readNext()) != null) {
+        if (data.length != headers.length)
+          throw new RuntimeException("Revolut CSV row has " + data.length + " columns but header has " + headers.length);
+
+        Map<String, Object> rowData = new HashMap<>();
+        for (int i = 0; i < headers.length; i++) {
+          rowData.put(headers[i], data[i]);
+        }
+
+        BankTransactionDto bankTransactionDto = bankTransactionMapper.toDtoFromRevolut(rowData);
+        bankTransactionDtos.add(bankTransactionDto);
+      }
+    } catch (com.opencsv.exceptions.CsvValidationException e) {
+      throw new RuntimeException("Failed to parse Revolut CSV data", e);
     }
+
     return bankTransactionDtos;
   }
 
@@ -174,6 +179,8 @@ public class BankTransactionService {
 
         bankTransactionDtos.add(bankTransactionDto);
       }
+    } catch (com.opencsv.exceptions.CsvValidationException e) {
+      throw new RuntimeException("Failed to parse Degiro CSV data", e);
     }
 
     return bankTransactionDtos;
@@ -203,4 +210,3 @@ public class BankTransactionService {
   }
 
 }
-

--- a/src/main/java/com/rondinella/moneymanageapi/banktransactions/BankTransactionsController.java
+++ b/src/main/java/com/rondinella/moneymanageapi/banktransactions/BankTransactionsController.java
@@ -11,7 +11,6 @@ import java.sql.Timestamp;
 import java.util.List;
 
 @RestController
-@CrossOrigin(origins = "http://localhost:4200") // Allow requests from Angular app
 @RequestMapping(path = "/api/banks/transactions", produces = "application/json")
 public class BankTransactionsController {
 

--- a/src/main/java/com/rondinella/moneymanageapi/banktransactions/BankTransactionsController.java
+++ b/src/main/java/com/rondinella/moneymanageapi/banktransactions/BankTransactionsController.java
@@ -23,7 +23,7 @@ public class BankTransactionsController {
 
   @GetMapping
   public ResponseEntity<?> getAllTransactions() {
-    return new ResponseEntity<>(bankTransactionService.findAllTransactions(), HttpStatus.CREATED);
+    return new ResponseEntity<>(bankTransactionService.findAllTransactions(), HttpStatus.OK);
   }
 
   @GetMapping("/accounts/{accountName}")

--- a/src/main/java/com/rondinella/moneymanageapi/brokertransactions/BrokerTransactionsController.java
+++ b/src/main/java/com/rondinella/moneymanageapi/brokertransactions/BrokerTransactionsController.java
@@ -13,7 +13,6 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 
 @RestController
-@CrossOrigin(origins = "http://localhost:4200") // Allow requests from Angular app
 @RequestMapping(path = "/api/brokers/transactions", produces = "application/json")
 public class BrokerTransactionsController {
   final

--- a/src/main/java/com/rondinella/moneymanageapi/common/configurations/AccountBaseProperties.java
+++ b/src/main/java/com/rondinella/moneymanageapi/common/configurations/AccountBaseProperties.java
@@ -1,0 +1,23 @@
+package com.rondinella.moneymanageapi.common.configurations;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@ConfigurationProperties(prefix = "app.account-base")
+public class AccountBaseProperties {
+
+  private Map<String, BigDecimal> amounts = new HashMap<>();
+
+  public Map<String, BigDecimal> getAmounts() {
+    return amounts;
+  }
+
+  public void setAmounts(Map<String, BigDecimal> amounts) {
+    this.amounts = amounts;
+  }
+}

--- a/src/main/java/com/rondinella/moneymanageapi/common/configurations/CorsConfig.java
+++ b/src/main/java/com/rondinella/moneymanageapi/common/configurations/CorsConfig.java
@@ -1,21 +1,31 @@
 package com.rondinella.moneymanageapi.common.configurations;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
-public class CorsConfig implements WebMvcConfigurer {
+public class CorsConfig {
 
   @Value("${app.cors.allowed-origins:http://localhost:4200}")
   private String[] allowedOrigins;
 
-  @Override
-  public void addCorsMappings(CorsRegistry registry) {
-    registry.addMapping("/api/**")
-        .allowedOrigins(allowedOrigins)
-        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-        .allowedHeaders("*");
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOrigins(Arrays.asList(allowedOrigins));
+    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    configuration.setAllowedHeaders(List.of("*"));
+    configuration.setAllowCredentials(true);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/api/**", configuration);
+    return source;
   }
 }

--- a/src/main/java/com/rondinella/moneymanageapi/common/configurations/CorsConfig.java
+++ b/src/main/java/com/rondinella/moneymanageapi/common/configurations/CorsConfig.java
@@ -1,0 +1,21 @@
+package com.rondinella.moneymanageapi.common.configurations;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+  @Value("${app.cors.allowed-origins:http://localhost:4200}")
+  private String[] allowedOrigins;
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/api/**")
+        .allowedOrigins(allowedOrigins)
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+        .allowedHeaders("*");
+  }
+}

--- a/src/main/java/com/rondinella/moneymanageapi/common/configurations/SecurityConfig.java
+++ b/src/main/java/com/rondinella/moneymanageapi/common/configurations/SecurityConfig.java
@@ -9,7 +9,6 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -29,7 +28,10 @@ public class SecurityConfig {
                                                  CorsConfigurationSource corsConfigurationSource) throws Exception {
     http
         .cors(cors -> cors.configurationSource(corsConfigurationSource))
-        .csrf(AbstractHttpConfigurer::disable)
+        // Stateless token API: CSRF tokens are not applicable to the JSON
+        // endpoints, which are authenticated solely via the Authorization
+        // header (no cookies/session). CSRF stays active for any other path.
+        .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/api/auth/**").permitAll()
             .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/v2/api-docs", "/swagger-resources/**", "/webjars/**").permitAll()

--- a/src/main/java/com/rondinella/moneymanageapi/common/configurations/SecurityConfig.java
+++ b/src/main/java/com/rondinella/moneymanageapi/common/configurations/SecurityConfig.java
@@ -1,0 +1,61 @@
+package com.rondinella.moneymanageapi.common.configurations;
+
+import com.rondinella.moneymanageapi.auth.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                 JwtAuthenticationFilter jwtAuthenticationFilter,
+                                                 AuthenticationProvider authenticationProvider,
+                                                 CorsConfigurationSource corsConfigurationSource) throws Exception {
+    http
+        .cors(cors -> cors.configurationSource(corsConfigurationSource))
+        .csrf(AbstractHttpConfigurer::disable)
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/api/auth/**").permitAll()
+            .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/v2/api-docs", "/swagger-resources/**", "/webjars/**").permitAll()
+            .requestMatchers("/actuator/**").permitAll()
+            .anyRequest().authenticated())
+        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authenticationProvider(authenticationProvider)
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    return http.build();
+  }
+
+  @Bean
+  public AuthenticationProvider authenticationProvider(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
+    DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+    provider.setUserDetailsService(userDetailsService);
+    provider.setPasswordEncoder(passwordEncoder);
+    return provider;
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+    return configuration.getAuthenticationManager();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,8 @@ app.account-base.amounts[Revolut_Current]=94.24
 app.account-base.amounts[Revolut_Pocket]=79.86
 app.account-base.amounts[Revolut_Savings]=98.16
 
-# JWT: override the secret in real deployments (must be >= 32 chars for HS256)
-app.jwt.secret=change-me-money-manage-jwt-secret-please-override-0123456789
+# JWT: set app.jwt.secret (>= 32 chars) via environment/secret manager in real
+# deployments. If left unset, a secure random key is generated at startup
+# (issued tokens will not survive an application restart).
+#app.jwt.secret=
 app.jwt.expiration=86400000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,7 @@ app.cors.allowed-origins=http://localhost:4200
 app.account-base.amounts[Revolut_Current]=94.24
 app.account-base.amounts[Revolut_Pocket]=79.86
 app.account-base.amounts[Revolut_Savings]=98.16
+
+# JWT: override the secret in real deployments (must be >= 32 chars for HS256)
+app.jwt.secret=change-me-money-manage-jwt-secret-please-override-0123456789
+app.jwt.expiration=86400000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,11 @@ spring.jpa.hibernate.ddl-auto=update
 
 #spring.docker.compose.enabled=true
 #spring.docker.compose.file=compose.yaml
+
+# CORS: comma-separated list of allowed frontend origins
+app.cors.allowed-origins=http://localhost:4200
+
+# Account base amounts used as the reference point for balance reconstruction
+app.account-base.amounts[Revolut_Current]=94.24
+app.account-base.amounts[Revolut_Pocket]=79.86
+app.account-base.amounts[Revolut_Savings]=98.16


### PR DESCRIPTION
## Summary
Raccoglie le correzioni dalla code review e l'autenticazione JWT (richiesta esplicita).

### Autenticazione (JWT)
- `spring-boot-starter-security` + `jjwt` (HS256)
- `User` entity + `UserRepository` (**export Spring Data REST disabilitato** per non esporre gli hash)
- `JwtService`, `JwtAuthenticationFilter`, `ApplicationUserDetailsService`
- `AuthController`: `POST /api/auth/register`, `POST /api/auth/login` → `{ token }`
- `SecurityConfig`: stateless; pubblici `/api/auth/**`, swagger, actuator; tutto il resto richiede `Bearer` token
- Secret/scadenza configurabili via `app.jwt.*`

### Fix dalla review
- `getAllTransactions()` → `200 OK` invece di `201 CREATED`
- `revolutCsv()` usa `opencsv` invece di `split(",")` (si rompeva con virgole nei campi)
- CORS esternalizzato in `app.cors.allowed-origins` via `CorsConfigurationSource` (niente più `@CrossOrigin` hardcoded)
- Importi base Revolut spostati in `app.account-base.amounts[...]`

## CI
✅ `build` e `dependency-submission` verdi (incluso il `contextLoads` con Spring Security attivo). Il primo push era rosso per un catch di `CsvValidationException` inesistente in opencsv 3.7: corretto.

## Note
Richiede la PR frontend gemella (login + interceptor) per funzionare end-to-end. `@SneakyThrows` lasciato invariato (stile, non bug).

## Test plan
- [ ] `POST /api/auth/register` → ritorna un token
- [ ] `POST /api/auth/login` con credenziali valide → token; non valide → 403/401
- [ ] `GET /api/banks/transactions` senza token → 401/403; con `Bearer` valido → 200
- [ ] Upload CSV Revolut con virgole nei campi → parsing corretto